### PR TITLE
allow multiple relays to be added to the relay list on start

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ usage: dart run bin/nostr_console.dart [OPTIONS]
                                     public key derived from a well known private key. When given, posts/replies can't be sent. 
       -k, --prikey  <private key>   The hex private key of user whose events and feed are shown. Also used to sign events 
                                     sent. Default is same-as-above hard-coded well known private key. 
-      -r, --relay   <relay wss url> The relay url that is used as main relay. Default is wss://nostr-relay.untethr.me.
+      -r, --relay   <relay wss url> The comma separated relay urls that are used as main relay. Default is wss://nostr-relay.untethr.me.
       -d, --days    <N as num>      The latest number of days for which events are shown. Default is 1.
       -q, --request <REQ string>    This request is sent verbatim to the default relay. It can be used to receive all events
                                     from a relay. If not provided, then events for default or given user are shown.

--- a/bin/nostr_console.dart
+++ b/bin/nostr_console.dart
@@ -120,19 +120,15 @@ Future<void> main(List<String> arguments) async {
 
       // handle relay related argument
       if( argResults[relayArg] != null) {
-        List<String> userRelayList = argResults[relayArg].split(",");
-        List<String> parsedRelays = [];
-        for (var i = 0; i < userRelayList.length; i++) {
-          if( userRelayList[i].startsWith("wss://")) {
-            if( !parsedRelays.contains(userRelayList[i])) {
-              parsedRelays.add(userRelayList[i]);
-            } else {
-              print("The given relay ${userRelayList[i]} is already present in the default relays for the app, which are $parsedRelays");
-            }
+        Set<String> userRelayList = Set.from(argResults[relayArg].split(","));
+        Set<String> parsedRelays = {};
+        userRelayList.forEach((relay) {
+          if(relay.startsWith(RegExp(r'^ws[a-z]?:\/\/'))) {
+            parsedRelays.add(relay);
           } else {
-            print("The provided relay entry: ${userRelayList[i]} does not start with wss://, omitting");
+            print("The provided relay entry: $relay does not start with ws:// or wss://, omitting");
           }
-        }
+        });
 
         // verify that there is at least one valid relay they provided, otherwise keep defaults
         if (parsedRelays.length > 0) {

--- a/bin/nostr_console.dart
+++ b/bin/nostr_console.dart
@@ -123,7 +123,7 @@ Future<void> main(List<String> arguments) async {
         Set<String> userRelayList = Set.from(argResults[relayArg].split(","));
         Set<String> parsedRelays = {};
         userRelayList.forEach((relay) {
-          if(relay.startsWith(RegExp(r'^ws[a-z]?:\/\/'))) {
+          if(relay.startsWith(RegExp(r'^ws[s]?:\/\/'))) {
             parsedRelays.add(relay);
           } else {
             print("The provided relay entry: $relay does not start with ws:// or wss://, omitting");

--- a/bin/nostr_console.dart
+++ b/bin/nostr_console.dart
@@ -120,16 +120,18 @@ Future<void> main(List<String> arguments) async {
 
       // handle relay related argument
       if( argResults[relayArg] != null) {
-        String newRelay = argResults[relayArg];
-        if( newRelay.startsWith("wss://")) {
-          if( !gListRelayUrls1.contains(newRelay)) {
-            print("Also going to use new relay: $newRelay apart from the relays $gListRelayUrls1");
-            gListRelayUrls1.add( newRelay);
+        List<String> relayList = argResults[relayArg].split(",");
+        for (var i = 0; i < relayList.length; i++) {
+          if( relayList[i].startsWith("wss://")) {
+            if( !gListRelayUrls1.contains(relayList[i])) {
+              print("Also going to use new relay: ${relayList[i]} apart from the relays $gListRelayUrls1");
+              gListRelayUrls1.add(relayList[i]);
+            } else {
+              print("The given relay ${relayList[i]} is already present in the default relays for the app, which are $gListRelayUrls1");
+            }
           } else {
-            print("The given relay $newRelay is already present in the default relays for the app, which are $gListRelayUrls1");
+            print("The provided relay does not start with wss:// so not going to use it.");
           }
-        } else {
-          print("The provided relay does not start with wss:// so not going to use it.");
         }
       }
 

--- a/bin/nostr_console.dart
+++ b/bin/nostr_console.dart
@@ -120,19 +120,28 @@ Future<void> main(List<String> arguments) async {
 
       // handle relay related argument
       if( argResults[relayArg] != null) {
-        List<String> relayList = argResults[relayArg].split(",");
-        for (var i = 0; i < relayList.length; i++) {
-          if( relayList[i].startsWith("wss://")) {
-            if( !gListRelayUrls1.contains(relayList[i])) {
-              print("Also going to use new relay: ${relayList[i]} apart from the relays $gListRelayUrls1");
-              gListRelayUrls1.add(relayList[i]);
+        List<String> userRelayList = argResults[relayArg].split(",");
+        List<String> parsedRelays = [];
+        for (var i = 0; i < userRelayList.length; i++) {
+          if( userRelayList[i].startsWith("wss://")) {
+            if( !parsedRelays.contains(userRelayList[i])) {
+              parsedRelays.add(userRelayList[i]);
             } else {
-              print("The given relay ${relayList[i]} is already present in the default relays for the app, which are $gListRelayUrls1");
+              print("The given relay ${userRelayList[i]} is already present in the default relays for the app, which are $parsedRelays");
             }
           } else {
-            print("The provided relay does not start with wss:// so not going to use it.");
+            print("The provided relay entry: ${userRelayList[i]} does not start with wss://, omitting");
           }
         }
+
+        // verify that there is at least one valid relay they provided, otherwise keep defaults
+        if (parsedRelays.length > 0) {
+          gListRelayUrls1 = parsedRelays;
+        } else {
+          print("No valid relays were provided, using the default relay list");
+        }
+
+        print("Relay List: ${gListRelayUrls1}");
       }
 
       if( argResults[lastdaysArg] != null) {

--- a/lib/relays.dart
+++ b/lib/relays.dart
@@ -217,7 +217,7 @@ class Relays {
 
 Relays relays = Relays({}, {}, {});
 
-void getContactFeed(List<String> relayUrls, Set<String> setContacts, int numEventsToGet, int sinceWhen) {
+void getContactFeed(Set<String> relayUrls, Set<String> setContacts, int numEventsToGet, int sinceWhen) {
   
   List<String> contacts = setContacts.toList();
   //print("in getContactFeed: numEventsToGet = $numEventsToGet numContacts = ${setContacts.length} num contacts list = ${contacts.length}");
@@ -244,25 +244,25 @@ void getContactFeed(List<String> relayUrls, Set<String> setContacts, int numEven
   return;
 }
 
-void getUserEvents(List<String> serverUrls, String publicKey, int numUserEvents, int sinceWhen) {
+void getUserEvents(Set<String> serverUrls, String publicKey, int numUserEvents, int sinceWhen) {
   serverUrls.forEach((serverUrl) {
       relays.getUserEvents(serverUrl, publicKey, numUserEvents, sinceWhen); 
     });
 }
 
-void getMentionEvents(List<String> serverUrls, Set<String> ids, int numUserEvents, int sinceWhen, String tagToGet) {
+void getMentionEvents(Set<String> serverUrls, Set<String> ids, int numUserEvents, int sinceWhen, String tagToGet) {
   serverUrls.forEach((serverUrl) {
       relays.getMentionEvents(serverUrl, ids, numUserEvents, sinceWhen, tagToGet); 
     });
 }
 
-getKindEvents(List<int> kind, List<String> serverUrls, int limit, int sinceWhen) {
+getKindEvents(List<int> kind, Set<String> serverUrls, int limit, int sinceWhen) {
   serverUrls.forEach((serverUrl) {
       relays.getKindEvents(kind, serverUrl, limit, sinceWhen); 
     });
 }
 
-void getMultiUserEvents(List<String> serverUrls, List<String> publicKeys, int numUserEvents, int sinceWhen) {
+void getMultiUserEvents(Set<String> serverUrls, List<String> publicKeys, int numUserEvents, int sinceWhen) {
   if( gDebug > 0) print("Sending multi user request for ${publicKeys.length} users");
   
   for(var serverUrl in serverUrls) {
@@ -279,7 +279,7 @@ void getMultiUserEvents(List<String> serverUrls, List<String> publicKeys, int nu
 }
 
 // send request for specific events whose id's are passed as list eventIds
-void sendEventsRequest(List<String> serverUrls, Set<String> eventIds) {
+void sendEventsRequest(Set<String> serverUrls, Set<String> eventIds) {
   if( eventIds.length == 0) 
     return;
 
@@ -289,15 +289,15 @@ void sendEventsRequest(List<String> serverUrls, Set<String> eventIds) {
   if( gDebug > 0) log.info("sending $getEventRequest");
   //print("send event req: $getEventRequest\n");
 
-  for(int i = 0; i < serverUrls.length; i++) {
-    relays.sendRequest(serverUrls[i], getEventRequest);
-  }
+  serverUrls.forEach((url) {
+    relays.sendRequest(url, getEventRequest);
+  });
 }
 
-void sendRequest(List<String> serverUrls, request) {
-  for(int i = 0; i < serverUrls.length; i++) {
-    relays.sendRequest(serverUrls[i], request);
-  }
+void sendRequest(Set<String> serverUrls, request) {
+  serverUrls.forEach((url) { 
+    relays.sendRequest(url, request);
+  });
 }
 
 Set<Event> getRecievedEvents() {

--- a/lib/settings.dart
+++ b/lib/settings.dart
@@ -242,7 +242,7 @@ usage: $exename [OPTIONS]
                                     well known private key. When given, posts/replies can't be sent.
       -k, --prikey  <private key>   The hex private key of user whose events and feed are shown. Also used to sign events 
                                     sent. Default is a hard-coded well known private key.
-      -r, --relay   <relay wss url> The relay url that is used as main relay. Default is wss://relay.damus.io.
+      -r, --relay   <relay wss url> The comma separated relay urls that are used as main relay. Default is wss://relay.damus.io.
       -d, --days    <N as num>      The latest number of days for which events are shown. Default is $gDefaultNumLastDays.
       -q, --request <REQ string>    This request is sent verbatim to the default relay. It can be used to recieve all events
                                     from a relay. If not provided, then events for default or given user are shown.

--- a/lib/settings.dart
+++ b/lib/settings.dart
@@ -50,16 +50,15 @@ int numFilePosts = 0, numUserPosts = 0, numFeedPosts = 0, numOtherPosts = 0;
 const String relayNostrInfo   = 'wss://relay.nostr.info';
 String defaultServerUrl       = "wss://relay.damus.io";
 
-List<String> gListRelayUrls1 = [ defaultServerUrl,
+Set<String> gListRelayUrls1 = { defaultServerUrl,
                                 relayNostrInfo,
                                 "wss://nostr-relay.wlvs.space"
-                              ];
+                              };
 
-List<String> gListRelayUrls2 = [
-                              
+Set<String> gListRelayUrls2 = {    
                               "wss://nostr.oxtr.dev",
                               "wss://nostr.ono.re"
-                              ];
+                              };
 
 // well known disposable test private key
 const String gDefaultPublicKey  = "";


### PR DESCRIPTION
- allow multiple relays to be defined on console startup:

```
dart run bin/nostr_console.dart --relay wss://nostr.radixrat.com,wss://nostr.zebedee.cloud
...
Also going to use new relay: wss://nostr.radixrat.com apart from the relays [wss://relay.damus.io, wss://relay.nostr.info, wss://nostr-relay.wlvs.space]
Also going to use new relay: wss://nostr.zebedee.cloud apart from the relays [wss://relay.damus.io, wss://relay.nostr.info, wss://nostr-relay.wlvs.space, wss://nostr.radixrat.com
```

left as --relay to maximize backward compatibility, @vishalxl may have something else in mind for this type of feature though just saw someone post a question about it on nostr 