### PR TITLE
Public relay name change

### DIFF
--- a/lib/event_ds.dart
+++ b/lib/event_ds.dart
@@ -287,7 +287,7 @@ class EventData {
         String server = defaultServerUrl;
         if( tag.length >=3 ) {
           server = tag[2].toString();
-          if( server == 'wss://nostr.rocks' || server == "wss://nostr.bitcoiner.social") {
+          if( server == 'wss://nostr.rocks' || server == "wss://offchain.pub") {
             server = defaultServerUrl;
           }
         }

--- a/lib/settings.dart
+++ b/lib/settings.dart
@@ -63,7 +63,7 @@ Set<String> gListRelayUrls1 = { defaultServerUrl,
 
 Set<String> gListRelayUrls2 = {    
                              // "wss://nostr.oxtr.dev",
-                              "wss://nostr.bitcoiner.social",
+                              "wss://offchain.pub",
                                  "wss://nostr.zerofeerouting.com",
                                  "wss://nostr-relay.trustbtc.org",
                                  "wss://relay.stoner.com"

--- a/scripts/configfile.cfg
+++ b/scripts/configfile.cfg
@@ -36,7 +36,7 @@ nostr_servers=(
     "wss://nostr.onsats.org"
     "wss://nostr-relay.digitalmob.ro"
 
-    "wss://nostr.bitcoiner.social"
+    "wss://offchain.pub"
 
     "wss://relay.valireum.net"
     "wss://nostr-relay.trustbtc.org"


### PR DESCRIPTION
nostr.bitcoiner.social -> offchain.pub

note1zpgy9f8tlwdwhhwtzy50vpl72qkunzhmy57p4f5xaf8h57pfvwpschwe74

> Before I deployed the new pay-to-relay server, I ran a public relay under a "nostr" subdomain. I've since renamed my public relay to wss://offchain.pub. Much cooler name. Better represents how nostr isn't something this domain handles on the side, it's the primary purpose. Raison d'etre.
> 
> Both offchain.pub and the "nostr" subdomain will work concurrently for awhile, pointing to the same public relay server. But I'll eventually deprecate the "nostr" subdomain and redirect requests to the new offchain.pub name.

There are also a few references to the old subdomain in `test_event_file.csv`, but I didn't touch those as I don't want to assume that it's even necessary. But if you wanted to change that too I would just do something like:

```bash
sed -i 's/nostr.bitcoiner.social/offchain.pub/g' test_event_file.csv
```